### PR TITLE
Django 1.7 support

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -18,7 +18,8 @@ if not settings.configured:
         ),
         INSTALLED_APPS = (
             'template_analyzer',
-        )
+        ),
+        MIDDLEWARE_CLASSES = (),
     )
 
 def runtests():

--- a/template_analyzer/templates/placeholder_tests/tag_exception.html
+++ b/template_analyzer/templates/placeholder_tests/tag_exception.html
@@ -1,0 +1,3 @@
+{% load template_analyzer_test_tags %}
+
+{% placeholder %}

--- a/template_analyzer/tests.py
+++ b/template_analyzer/tests.py
@@ -1,3 +1,4 @@
+from django.template.base import TemplateSyntaxError
 from django.template.loader import get_template
 from django.test.testcases import TestCase
 
@@ -60,6 +61,8 @@ class PlaceholderTestCase(TestCase):
         placeholders = get_placeholders('placeholder_tests/variable_extends.html')
         self.assertEqual(sorted(placeholders), [])
 
-    def test_ignore_variable_extends(self):
-        placeholders = get_placeholders('placeholder_tests/variable_extends_default.html')
-        self.assertEqual(sorted(placeholders), sorted([u'one', u'three', u'two']))
+    def test_tag_placeholder_exception(self):
+        exp = TemplateSyntaxError('placeholder tag requires 2 arguments')
+        with self.assertRaises(TemplateSyntaxError) as tsx:
+            get_placeholders('placeholder_tests/tag_exception.html')
+        self.assertEqual(tsx.exception.message, exp.message)


### PR DESCRIPTION
- (Tests) MIDDLEWARE_CLASSES set, to remove Django 1.7 warning
- (Tests) Added an exception test case
- Django 1.7 no longer has ConstantIncludeNode, updated _scan_node() to work.
